### PR TITLE
Bump jackson.version from 2.9.10 to 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <runtime></runtime>
 
     <!-- Dependency versions -->
-    <jackson.version>2.9.10</jackson.version>
+    <jackson.version>2.12.1</jackson.version>
     <apache.ant.version>1.8.0</apache.ant.version>
     <apache.camel.version>2.15.6</apache.camel.version>
     <apache.pdfbox.version>1.8.16</apache.pdfbox.version>


### PR DESCRIPTION
Bumps `jackson.version` from 2.9.10 to 2.12.1.

Updates `jackson-core` from 2.9.10 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.9.10...jackson-core-2.12.1)

Updates `jackson-databind` from 2.9.10 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-annotations` from 2.9.10 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-dataformat-xml` from 2.9.10 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson-dataformat-xml/releases)
- [Commits](https://github.com/FasterXML/jackson-dataformat-xml/compare/jackson-dataformat-xml-2.9.10...jackson-dataformat-xml-2.12.1)